### PR TITLE
Allow 

### DIFF
--- a/tokterm/public/index.html
+++ b/tokterm/public/index.html
@@ -8,11 +8,11 @@
       @import url('https://fonts.googleapis.com/css2?family=Fira+Mono&display=swap');
       body { margin: 0; }
       html, body, #terminal {
-        overflow: hidden;
         width: 100%;
         height: 100%;
         font-size: 16px;
         line-height: 17px;
+        background: black;
       }
     </style>
     <meta name="viewport" content="width=device-width,initial-scale=1" />
@@ -20,9 +20,6 @@
   </head>
 
   <body>
-    <div class="fullscreen">
-      <div id="terminal"></div>
-      <!--script type="module" src="main.js"></script-->
-    </div>
+    <div id="terminal"></div>
   </body>
 </html>

--- a/tokterm/src/tty.rs
+++ b/tokterm/src/tty.rs
@@ -346,7 +346,7 @@ impl Tty
             let mut inner = self.inner_async.lock().await;
             let cursor_pos = inner.cursor_pos;
             inner.line.insert_str(cursor_pos, data);
-            inner.cursor_pos += 1;
+            inner.cursor_pos += data.len();
             
             let right = if inner.cursor_pos < inner.line.len() {
                 Some(inner.line[inner.cursor_pos..].to_string())


### PR DESCRIPTION
This PR makes copy & paste fully supported in the terminal.

I've replaced the onKey events with onData, as it seems is the recommended approach for xTerm.js.

I've looked at how vscode was doing it and it seemed similar:
https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts#L596-L599